### PR TITLE
fix println

### DIFF
--- a/modules/chui-remote/src/lambdaisland/chui/remote.cljs
+++ b/modules/chui-remote/src/lambdaisland/chui/remote.cljs
@@ -2,7 +2,6 @@
   {:dev/always true}
   (:require [cljs.pprint :as pp :include-macros true]
             [cljs.test :as t]
-            [clojure.browser.repl :as browser-repl]
             [clojure.string :as str]
             [cognitect.transit :as transit]
             [goog.dom :as gdom]


### PR DESCRIPTION
When I try to use `println` in the tests, I find it doens't work anymore (but `js/console.log` works), just become a no-op. 

It looks like it's because `chui.remote` imports `clojure.browser.repl`, which override the `cljs.core/*print-fn*`. 

https://github.com/clojure/clojurescript/blob/a15247a743d4d1c5d73224038f7289c447b38ca8/src/main/cljs/clojure/browser/repl.cljs#L57-L58

 However the import of the `clojure.browser.repl` is not at all in that ns, so i think it's safe to remove it and fix this bug.