### PR TITLE
Stop hiding passing tests by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Changed
 
+- Change default in UI to show passing tests
+
 # 0.0.156 (2020-08-26 / 460519c)
 
 ## Fixed

--- a/README.md
+++ b/README.md
@@ -187,11 +187,11 @@ inspect previous results.
 
 This third column shows namespaces and test vars. Note that if you have a lot of
 tests this can become hard to navigate, this is why you can enable the checkbox
-to only show failing tests.
+to hide passing tests.
 
 Finally the fourth column shows the individual assertions, with full details.
 Which assertions are visible depends on the selection in the third column. By
-default all failing tests get selected.
+default all failing assertions are shown.
 
 ### Limitations
 

--- a/test/lambdaisland/chui_demo/a_test.cljs
+++ b/test/lambdaisland/chui_demo/a_test.cljs
@@ -26,6 +26,10 @@
                    (log/info :once :after)
                    (done)))})
 
+(deftest succeeding-test
+  (is true)
+  (is (= 1 1)))
+
 (deftest aa-test
   (is (= 1 1))
   (is (= [{:x 123}] [{:x 124}]))


### PR DESCRIPTION
## The Problem
When you start up a test suite of a very large project in Chui, it seems to be completely broken. The fans of your computer start whirring, but nothing seems to be happening. You start clicking on random things and looking around trying to work out what's happening, before you realize that there's a tiny checkbox at the top hiding all the tests by default.

That's to say, I think it makes a lot of sense to have this option, especially when writing new tests, but I don't think it makes a lot of sense as a default option, and by virtue of it being such a small option it feels hidden.

## The Solution (for now)
I've simply changed the default behaviour from "Show only failing :ballot_box_with_check:" to "Hide passing tests" with an unchecked box. Ideally, in the future we could save this to local storage to allow this to be remembered, but that's beyond the scope of the work I want to do right now.

In the code, I also felt that re-framing the boolean made the logic a bit easier to read.