### PR TITLE
bump glogi version to 1.0.100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## Changed
 
+- Upgrade glogi dependency
+
 # 1.0.173 (2021-02-26 / 1e3ed0b)
 
 ## Changed

--- a/modules/chui-core/deps.edn
+++ b/modules/chui-core/deps.edn
@@ -1,4 +1,4 @@
 {:paths ["src"]
- :deps  {lambdaisland/glogi          {:mvn/version "1.0.70"}
+ :deps  {lambdaisland/glogi          {:mvn/version "1.0.100"}
          lambdaisland/deep-diff2     {:mvn/version "2.0.108" :exclusions [org.clojure/clojurescript]}
          kitchen-async/kitchen-async {:mvn/version "0.1.0-SNAPSHOT" :exclusions [org.clojure/core.async]}}}


### PR DESCRIPTION
Resolves https://github.com/lambdaisland/chui/issues/14

Clojurescript 1.10.844 includes Google Closure 0.0-20201211-3e6c510d, which contains breaking changes in logging modules. Bump glogi so that chui works with Clojurescript 1.10.844.

See: https://github.com/lambdaisland/glogi/issues/10
