### PR TITLE
Bump glogi to 1.1.144

### DIFF
--- a/modules/chui-core/deps.edn
+++ b/modules/chui-core/deps.edn
@@ -1,4 +1,4 @@
 {:paths ["src"]
- :deps  {lambdaisland/glogi          {:mvn/version "1.0.100"}
+ :deps  {com.lambdaisland/glogi      {:mvn/version "1.1.144"}
          lambdaisland/deep-diff2     {:mvn/version "2.0.108" :exclusions [org.clojure/clojurescript]}
          kitchen-async/kitchen-async {:mvn/version "0.1.0-SNAPSHOT" :exclusions [org.clojure/core.async]}}}


### PR DESCRIPTION
Similarly to https://github.com/lambdaisland/chui/pull/15 another bump to `glogi` is needed for the newest versions of clojurescript and shadow-cljs:

````
 thheller/shadow-cljs {:mvn/version "2.17.8"}
 org.clojure/clojurescript {:mvn/version "1.10.914"}
````

without this bump, shadow-cljs build with chui fails with:
````
The required namespace "goog.debug.LogBuffer" is not available, it was required by "lambdaisland/glogi/console.cljs".
````
and it goes away with `glogi` bumped to `1.1.144`