### PR TITLE
Ensure string in `re-find` call in case of nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Fix Safari line-and-col reporting bug
+
 ## Added
 
 ## Fixed

--- a/modules/chui-core/src/lambdaisland/chui/runner.cljs
+++ b/modules/chui-core/src/lambdaisland/chui/runner.cljs
@@ -90,8 +90,8 @@
         (let [line-col (drop (- (count frame) 2) frame)
               file     (str/join ":" (take (- (count frame) 2) frame))]
           {:file   file
-           :line   (js/parseInt (re-find #"\d+" (first line-col)) 10)
-           :column (js/parseInt (re-find #"\d+" (second line-col)) 10)})))))
+           :line   (js/parseInt (re-find #"\d+" (str (first line-col))) 10)
+           :column (js/parseInt (re-find #"\d+" (str (second line-col))) 10)})))))
 
 (defmulti report :type)
 (defmethod report :default [_])


### PR DESCRIPTION
Under some conditions, Safari won't report stack data in the way `lambdaisland.chui.runner/file-and-line` expects. It blows up when trying to detect the location of a test failure on the `re-find` calls since at that point it doesn't have a string. This can turn a passing test into a test that's erroring out.

This commit adds a guard to ensure `re-find` is always handed a string. It might be `""` in the case above in Safari, probably leading to reporting a failing line incorrectly. But the comments above the code in `file-and-line` suggest this hasn't been working entirely correctly anyway. It's a no-op in Firefox and Chrome.

See also #20.