### PR TITLE
Pin kitchen-async to a specific SNAPSHOT version

### DIFF
--- a/modules/chui-core/deps.edn
+++ b/modules/chui-core/deps.edn
@@ -1,4 +1,5 @@
 {:paths ["src"]
  :deps  {com.lambdaisland/glogi      {:mvn/version "1.1.144"}
          lambdaisland/deep-diff2     {:mvn/version "2.0.108" :exclusions [org.clojure/clojurescript]}
-         kitchen-async/kitchen-async {:mvn/version "0.1.0-SNAPSHOT" :exclusions [org.clojure/core.async]}}}
+         ;; Waiting for a non-snapshot release: https://github.com/athos/kitchen-async/issues/7
+         kitchen-async/kitchen-async {:mvn/version "0.1.0-20191108.004735-9" :exclusions [org.clojure/core.async]}}}


### PR DESCRIPTION
So that chui doesn't depend on a SNAPSHOT which could be updated at any time.

<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
