### PR TITLE
Switch over to our preferred kitchen-async fork.

### DIFF
--- a/modules/chui-core/deps.edn
+++ b/modules/chui-core/deps.edn
@@ -2,4 +2,4 @@
  :deps  {com.lambdaisland/glogi      {:mvn/version "1.1.144"}
          lambdaisland/deep-diff2     {:mvn/version "2.0.108" :exclusions [org.clojure/clojurescript]}
          ;; Waiting for a non-snapshot release: https://github.com/athos/kitchen-async/issues/7
-         kitchen-async/kitchen-async {:mvn/version "0.1.0-20191108.004735-9" :exclusions [org.clojure/core.async]}}}
+         mhuebert/kitchen-async {:mvn/version "0.1.0" :exclusions [org.clojure/core.async]}}}


### PR DESCRIPTION
Use [mhueber's fork of kitchen-async](https://github.com/mhuebert/kitchen-async) that we've used in other projects.
